### PR TITLE
pixi alternative method for installing on linux/x86_64

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -83,21 +83,19 @@ To update the gmx_clusterByFeatrues package use following command:
 update of dependent packages like numpy, scipy, matplotlib etc.
 
 
-****
-
 Installing with `pixi` (https://pixi.sh/latest/installation) on linux/x86_64
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-```
-# install pixi 
-mkdir gmx_clusterByFeatures
-cd gmx_clusterByFeatures
-pixi init
-pixi add python=3.11 numpy scipy matplotlib scikit-learn pybind11 gromacs
-pixi add --pypi gmx-clusterByFeatures
-pixi run gmx_clusterByFeatures
-```
 
-****
+.. code:: bash
+
+    # install pixi 
+    mkdir gmx_clusterByFeatures
+    cd gmx_clusterByFeatures
+    pixi init
+    pixi add python=3.11 numpy scipy matplotlib scikit-learn pybind11 gromacs
+    pixi add --pypi gmx-clusterByFeatures
+    pixi run gmx_clusterByFeatures
 
 
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -85,6 +85,20 @@ update of dependent packages like numpy, scipy, matplotlib etc.
 
 ****
 
+Installing with `pixi` (https://pixi.sh/latest/installation) on linux/x86_64
+
+```
+# install pixi 
+mkdir gmx_clusterByFeatures
+cd gmx_clusterByFeatures
+pixi init
+pixi add python=3.11 numpy scipy matplotlib scikit-learn pybind11 gromacs
+pixi add --pypi gmx-clusterByFeatures
+pixi run gmx_clusterByFeatures
+```
+
+****
+
 
 
 Installation from source-code

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,23 @@
+[workspace]
+channels = ["conda-forge"]
+name = "gmx_clusterByFeatures"
+platforms = ["linux-64"]
+version = "0.1.0"
+
+[tasks]
+
+[dependencies]
+python = "3.11.*"
+numpy = ">=2.3.2,<3"
+scipy = ">=1.16.1,<2"
+matplotlib = ">=3.10.5,<4"
+scikit-learn = ">=1.7.1,<2"
+pybind11 = ">=3.0.0,<4"
+gxx = ">=15.1.0,<15.2"
+cmake = ">=4.1.0,<5"
+jupyterlab = ">=4.4.6,<5"
+pkgconfig = ">=1.5.5,<2"
+gromacs = ">=2025.2,<2026"
+
+[pypi-dependencies]
+gmx-clusterbyfeatures = ">=0.1.29, <0.2"


### PR DESCRIPTION
With a sample `pixi.toml` file...

YMV, I find it easier to manage because self contained. Quick and dirty setup, leveraging conda-forge and pypi.

Best regards

Tru